### PR TITLE
Not working with chef >=12

### DIFF
--- a/lib/chef/resource/ssh_cluster.rb
+++ b/lib/chef/resource/ssh_cluster.rb
@@ -15,7 +15,7 @@ class Chef::Resource::SshCluster < Chef::Resource::LWRPBase
   end
 
   # We are not interested in Chef's cloning behavior here.
-  def load_prior_resource(type, name)
+  def load_prior_resource(*args)
     Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with NOOP")
   end
 end

--- a/lib/chef/resource/ssh_cluster.rb
+++ b/lib/chef/resource/ssh_cluster.rb
@@ -15,7 +15,7 @@ class Chef::Resource::SshCluster < Chef::Resource::LWRPBase
   end
 
   # We are not interested in Chef's cloning behavior here.
-  def load_prior_resource
+  def load_prior_resource(type, name)
     Chef::Log.debug("Overloading #{resource_name}.load_prior_resource with NOOP")
   end
 end


### PR DESCRIPTION
Hi,
I was having this errors:

```
[2015-03-09T16:15:02+01:00] FATAL: Stacktrace dumped to .../.chef/local-mode-cache/cache/chef-stacktrace.out
[2015-03-09T16:15:02+01:00] DEBUG: RuntimeError: machine[front.website.inte] (@recipe_files::.../driver/ssh/front.rb line 4) had an error: RuntimeError: No Keys OR Password, No Can Do Compadre
.../gems/chef-provisioning-ssh-0.0.4/lib/chef/provisioning/ssh_driver/driver.rb:342:in `ensure_has_keys_or_password'
.../gems/chef-provisioning-ssh-0.0.4/lib/chef/provisioning/ssh_driver/driver.rb:328:in `updated_transport_options_hash'
.../gems/chef-provisioning-ssh-0.0.4/lib/chef/provisioning/ssh_driver/driver.rb:260:in `updated_ssh_machine_file_hash'
.../gems/chef-provisioning-ssh-0.0.4/lib/chef/provisioning/ssh_driver/driver.rb:95:in `allocate_machine'
.../gems/chef-provisioning-0.19/lib/chef/provider/machine.rb:28:in `block in <class:Machine>'
.../gems/chef-12.0.3/lib/chef/provider/lwrp_base.rb:60:in `instance_eval'
.../gems/chef-12.0.3/lib/chef/provider/lwrp_base.rb:60:in `recipe_eval_with_update_check'
.../gems/chef-12.0.3/lib/chef/provider/lwrp_base.rb:45:in `block in action'
.../gems/chef-provisioning-0.19/lib/chef/provider/machine.rb:33:in `block in <class:Machine>'
.../gems/chef-12.0.3/lib/chef/provider/lwrp_base.rb:60:in `instance_eval'
.../gems/chef-12.0.3/lib/chef/provider/lwrp_base.rb:60:in `recipe_eval_with_update_check'
.../gems/chef-12.0.3/lib/chef/provider/lwrp_base.rb:45:in `block in action'
.../gems/chef-provisioning-0.19/lib/chef/provider/machine.rb:51:in `block in <class:Machine>'
.../gems/chef-12.0.3/lib/chef/provider/lwrp_base.rb:60:in `instance_eval'
.../gems/chef-12.0.3/lib/chef/provider/lwrp_base.rb:60:in `recipe_eval_with_update_check'
.../gems/chef-12.0.3/lib/chef/provider/lwrp_base.rb:45:in `block in action'
.../gems/chef-12.0.3/lib/chef/provider.rb:145:in `run_action'
.../gems/chef-12.0.3/lib/chef/resource.rb:582:in `run_action'
.../gems/chef-12.0.3/lib/chef/runner.rb:49:in `run_action'
.../gems/chef-12.0.3/lib/chef/runner.rb:81:in `block (2 levels) in converge'
.../gems/chef-12.0.3/lib/chef/runner.rb:81:in `each'
.../gems/chef-12.0.3/lib/chef/runner.rb:81:in `block in converge'
.../gems/chef-12.0.3/lib/chef/resource_collection/resource_list.rb:83:in `block in execute_each_resource'
.../gems/chef-12.0.3/lib/chef/resource_collection/stepable_iterator.rb:116:in `call'
.../gems/chef-12.0.3/lib/chef/resource_collection/stepable_iterator.rb:116:in `call_iterator_block'
.../gems/chef-12.0.3/lib/chef/resource_collection/stepable_iterator.rb:85:in `step'
.../gems/chef-12.0.3/lib/chef/resource_collection/stepable_iterator.rb:104:in `iterate'
.../gems/chef-12.0.3/lib/chef/resource_collection/stepable_iterator.rb:55:in `each_with_index'
.../gems/chef-12.0.3/lib/chef/resource_collection/resource_list.rb:81:in `execute_each_resource'
.../gems/chef-12.0.3/lib/chef/runner.rb:80:in `converge'
.../gems/chef-12.0.3/lib/chef/client.rb:315:in `converge'
.../gems/chef-12.0.3/lib/chef/client.rb:400:in `block in run'
.../gems/chef-12.0.3/lib/chef/client.rb:399:in `catch'
.../gems/chef-12.0.3/lib/chef/client.rb:399:in `run'
.../gems/chef-12.0.3/lib/chef/application.rb:261:in `block in fork_chef_client'
.../gems/chef-12.0.3/lib/chef/application.rb:249:in `fork'
.../gems/chef-12.0.3/lib/chef/application.rb:249:in `fork_chef_client'
.../gems/chef-12.0.3/lib/chef/application.rb:215:in `block in run_chef_client'
.../gems/chef-12.0.3/lib/chef/local_mode.rb:38:in `with_server_connectivity'
.../gems/chef-12.0.3/lib/chef/application.rb:201:in `run_chef_client'
.../gems/chef-12.0.3/lib/chef/application/client.rb:355:in `block in interval_run_chef_client'
.../gems/chef-12.0.3/lib/chef/application/client.rb:345:in `loop'
.../gems/chef-12.0.3/lib/chef/application/client.rb:345:in `interval_run_chef_client'
.../gems/chef-12.0.3/lib/chef/application/client.rb:335:in `run_application'
.../gems/chef-12.0.3/lib/chef/application.rb:58:in `run'
.../gems/chef-12.0.3/bin/chef-client:26:in `<top (required)>'
/home/prambaud/.rbenv/versions/2.1.5/bin/chef-client:23:in `load'
/home/prambaud/.rbenv/versions/2.1.5/bin/chef-client:23:in `<main>'
Chef Client failed. 0 resources updated in 1.975345062 seconds
[2015-03-09T16:15:02+01:00] DEBUG: Server doesn't support resource history, skipping resource report.
[2015-03-09T16:15:02+01:00] ERROR: machine[front.website.inte] (@recipe_files::.../driver/ssh/front.rb line 4) had an error: RuntimeError: No Keys OR Password, No Can Do Compadre
[2015-03-09T16:15:02+01:00] FATAL: Chef::Exceptions::ChildConvergeError: Chef run process exited unsuccessfully (exit code 1)
```
Here a soltuion I found on stackoverflow: http://stackoverflow.com/questions/28028643/why-chef-metal-ssh-is-failed

Regards