### PR TITLE
Change Unix converge strategy to InstallSh

### DIFF
--- a/lib/chef/provisioning/ssh_driver/driver.rb
+++ b/lib/chef/provisioning/ssh_driver/driver.rb
@@ -6,7 +6,7 @@ require 'chef/provisioning/machine/basic_machine'
 require 'chef/provisioning/machine/unix_machine'
 require 'chef/provisioning/machine/windows_machine'
 require 'chef/provisioning/convergence_strategy/install_msi'
-require 'chef/provisioning/convergence_strategy/install_cached'
+require 'chef/provisioning/convergence_strategy/install_sh'
 require 'chef/provisioning/transport/winrm'
 require 'chef/provisioning/transport/ssh'
 require 'chef/provisioning/ssh_driver/version'
@@ -451,8 +451,8 @@ class Chef
             end
           else
             @unix_convergence_strategy ||= begin
-              Chef::Provisioning::ConvergenceStrategy::InstallCached.new(machine_options[:convergence_options],
-                                                                         config)
+              Chef::Provisioning::ConvergenceStrategy::InstallSh.new(machine_options[:convergence_options],
+                                                                     config)
             end
           end
         end

--- a/test/cookbooks/vagrant/recipes/test_ssh.rb
+++ b/test/cookbooks/vagrant/recipes/test_ssh.rb
@@ -25,7 +25,7 @@ machine "sshone" do
       'password' => 'vagrant'
     }
   }
-  recipe 'vagrant::sshtwo'
+  recipe 'vagrant::sshone'
   converge true
 end
 
@@ -33,10 +33,10 @@ machine_execute "touch /tmp/test.txt" do
   machine 'sshone'
 end
 
-machine_file "/tmp/install-client.sh" do
-  local_path "/tmp/install-client.sh"
+machine_file "/tmp/test.txt" do
+  local_path "/tmp/test.txt"
   machine 'sshone'
-  action :upload
+  action :download
 end
 
 machine "sshtwo" do
@@ -46,7 +46,7 @@ machine "sshtwo" do
     'ip_address' => '192.168.33.123',
     'username' => 'vagrant',
     'ssh_options' => {
-      'keys' => ['/Users/zzondlo/.ssh/id_rsa']
+      'keys' => ['~/.vagrant.d/insecure_private_key']
     }
   }
   recipe 'vagrant::sshtwo'


### PR DESCRIPTION
This change makes the unix converge strategy InstallSh.
There is a bug in provisioning in the Cached install
strategy with the new chef_version changes. InstallSh
works so changeing to it until the lower level stuff is
fixed.

Updated the tests to use vagrants insecure_key and changed
the machine file to a download so we are not reliant on local
state.