### PR TITLE
Allow the use of ssh-agent

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source 'https://rubygems.org'
 
+gem 'chef'
 # Specify your gem's dependencies in chef-provisioning-ssh.gemspec
 gemspec

--- a/README.md
+++ b/README.md
@@ -179,13 +179,17 @@ To test it out, clone the repo:
 
 `git clone https://github.com/chef/chef-provisioning-ssh.git`
 
-in the test directory there is a Vagrantfile with 2 nodes.
+in the test directory there is a Vagrantfile with 3 nodes.
 
 Run:
 
 `vagrant up`
 
-which will bring up both nodes.
+which will bring up all of the test nodes.
+
+Next, add the vagrant key to your ssh agent, this is used to authenticate to the third node:
+
+`ssh-add ~/.vagrant.d/insecure_private_key`
 
 Then run from the test directory:
 
@@ -193,7 +197,7 @@ Then run from the test directory:
 
 NOTE: if the first machine fails it will likely be a result of issues with your vagrant key.
 
-This will run chef-provisioning on each of the two vagrant nodes.
+This will run chef-provisioning on each of the three vagrant nodes.
 
 thats it.
 

--- a/lib/chef/provisioning/ssh_driver/driver.rb
+++ b/lib/chef/provisioning/ssh_driver/driver.rb
@@ -414,14 +414,16 @@ class Chef
               keys = ssh_hash['keys'] || false
               key_data = ssh_hash['key_data'] || false
               password = ssh_hash['password'] || false
+              agent = ssh_hash['use_agent'] || false
               has_either = ((password && password.kind_of?(String)) ||
                             (keys && !keys.empty? && keys.kind_of?(Array)) ||
-                            (key_data && !key_data.empty? && key_data.kind_of?(Array)))
+                            (key_data && !key_data.empty? && key_data.kind_of?(Array)) ||
+                            agent)
             else
               has_either = false
             end
           end
-          raise 'No Keys OR Password, No Can Do Compadre' unless has_either
+          raise 'No Keys, Password, or SSH Agent configured' unless has_either
           has_either
         end
 

--- a/test/Vagrantfile
+++ b/test/Vagrantfile
@@ -34,4 +34,14 @@ Vagrant.configure("2") do |c|
     end
   end
 
+  c.vm.define "ssh-three" do |three|
+    three.vm.box = "opscode-ubuntu-14.04"
+    three.vm.box_url = "https://opscode-vm-bento.s3.amazonaws.com/vagrant/virtualbox/opscode_ubuntu-14.04_chef-provisionerless.box"
+    three.vm.hostname = "target03.vagrantup.com"
+    three.vm.synced_folder ".", "/vagrant"
+    three.vm.network(:private_network, {:ip=>"192.168.33.124"})
+    three.vm.provider :virtualbox do |p|
+      p.customize ["modifyvm", :id, "--memory", "256"]
+    end
+  end
 end

--- a/test/cookbooks/vagrant/recipes/sshthree.rb
+++ b/test/cookbooks/vagrant/recipes/sshthree.rb
@@ -1,0 +1,11 @@
+#
+# Cookbook Name:: vagrant
+# Recipe:: sshthree
+#
+
+file '/tmp/sshthree.txt' do
+	action :create
+	owner 'root'
+	group 'root'
+	mode '0644'
+end

--- a/test/cookbooks/vagrant/recipes/sshthree_2.rb
+++ b/test/cookbooks/vagrant/recipes/sshthree_2.rb
@@ -1,0 +1,11 @@
+#
+# Cookbook Name:: vagrant
+# Recipe:: sshthree
+#
+
+file '/tmp/sshthree_2.txt' do
+	action :create
+	owner 'root'
+	group 'root'
+	mode '0644'
+end

--- a/test/cookbooks/vagrant/recipes/test_destroy.rb
+++ b/test/cookbooks/vagrant/recipes/test_destroy.rb
@@ -25,3 +25,12 @@ end
 machine "sshtwo" do
   action :destroy
 end
+
+machine "sshthree" do
+  run_list [ 'recipe[vagrant::sshthree_2]' ]
+  action :converge
+end
+
+machine "sshthree" do
+  action :destroy
+end

--- a/test/cookbooks/vagrant/recipes/test_ssh.rb
+++ b/test/cookbooks/vagrant/recipes/test_ssh.rb
@@ -1,29 +1,13 @@
 require 'chef/provisioning/ssh_driver'
 
-# require 'chef/config'
-# with_chef_server "http://192.168.1.182:8889", {
-#   :client_name => Chef::Config[:node_name],
-#   :signing_key_filename => Chef::Config[:client_key]
-# # }
-# with_chef_server({ :chef_server_url => "http://192.168.1.182:8889", :options => {
-#         :client_name => Chef::Config[:node_name],,
-#         :signing_key_filename => Chef::Config[:client_key],
-#         :local_mode => false
-#       })
-
-# with_ssh_cluster "/home/js4/metal/chef-metal/docs/examples/drivers/ssh"
 with_driver 'ssh'
 
 machine "sshone" do
-  #action :destroy
   action [:ready, :setup, :converge]
   machine_options :transport_options => {
     'ip_address' => '192.168.33.122',
     :username => 'vagrant',
     'ssh_options' => {
-      #:password => 'vagrant'
-      
-      #:keys => ['/home/vagrant/.ssh/id_rsa']
       :keys => ['~/.vagrant.d/insecure_private_key']
 
     },
@@ -45,23 +29,43 @@ machine_file "/tmp/test.txt" do
   action :download
 end
 
-# with_chef_server "https://api.opscode.com/organizations/double-z",
-#                      :client_name => Chef::Config[:node_name],
-#                      :signing_key_filename => Chef::Config[:client_key]
-
 with_driver 'ssh:chef'
 
 machine "sshtwo" do
-  # action :destroy
   action [:ready, :setup, :converge]
   machine_options 'transport_options' => {
     :ip_address => '192.168.33.123',
     'username' => 'vagrant',
     :ssh_options => {
       'password' => 'vagrant'
-      # :keys => ['~/.vagrant.d/insecure_private_key']
     }
   }
   recipe 'vagrant::sshtwo'
   converge true
+end
+
+machine "sshthree" do
+  action [:ready, :setup, :converge]
+  machine_options :transport_options => {
+    'ip_address' => '192.168.33.124',
+    :username => 'vagrant',
+    'ssh_options' => {
+      :use_agent => true
+    },
+    'options' => {
+      'ssh_pty_enable' => true
+    }
+  }
+  recipe 'vagrant::sshthree'
+  converge true
+end
+
+machine_execute "touch /tmp/test.txt" do
+  machine 'sshthree'
+end
+
+machine_file "/tmp/test.txt" do
+  local_path "/tmp/test.txt"
+  machine 'sshthree'
+  action :download
 end


### PR DESCRIPTION
Add a conditional to validate the :use_agent attribute before raising an
error due to lack of key or password data. Clarify error message if no
authentication options are present.