### PR TITLE
add provides to ssh_cluster, so that chef14 actually works with this

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ branches:
   only:
     - master
 rvm:
-  - 2.2.5
   - 2.3.1
 script: bundle exec rake build
 notifications:

--- a/lib/chef/provider/ssh_cluster.rb
+++ b/lib/chef/provider/ssh_cluster.rb
@@ -4,6 +4,7 @@ require 'cheffish'
 class Chef::Provider::SshCluster < Chef::Provider::LWRPBase
 
   use_inline_resources
+  provides :ssh_cluster
 
   def whyrun_supported?
     true


### PR DESCRIPTION
Turns out that we fail hard with a chef14 due to the missing provides, which was automatic until chef13